### PR TITLE
Set default maxBuffer to Infinity when creating compose client

### DIFF
--- a/packages/navy/src/drivers/docker-compose/client.js
+++ b/packages/navy/src/drivers/docker-compose/client.js
@@ -39,7 +39,7 @@ export function createComposeClient(navy: Navy): ComposeClient {
       } = opts
 
       const composeOpts: Object = {
-        maxBuffer: maxBuffer || 1024 * 1024,
+        maxBuffer: maxBuffer || Infinity,
       }
       const composeFilePath = await client.getDockerComposeFilePath()
 


### PR DESCRIPTION
We ran into an issue where our environment generates a docker-compose.yml
with a size of just over 1 MiB. The default value of maxBuffer when creating
a compose client was exactly 1 MiB, and if the size is larger than that,
it causes an exception which prevents creating the environment overall.

Similar to PR #77 commit 236aecce5574076e53af74fd03f3314168059dce