### PR TITLE
Fix the 'npm ci' command (was throwing exception)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "private": true,
+  "name": "navy-monorepo",
   "description": "This is a monorepo. Check packages/navy for the main navy package.",
   "options": {
     "mocha": "--compilers js:babel-register packages/*/src/{,**}/__tests__/*.js"


### PR DESCRIPTION
This works around an npm bug where running the ci command
would throw "Cannot read property 'length' of undefined"
if a name wasn't defined in package.json.

The workaround is simply to define a name in package.json.

Same as this bug:
https://npm.community/t/npm-ci-fails-with-obscure-error-on-nested-packages-if-package-json-omits-name/5715