### PR TITLE
Fix integration tests: docker pull, by logging in to Docker

### DIFF
--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -11,6 +11,10 @@ DOCKER_TAG=${DOCKER_TAG:-18.09-dind}
 DOCKER_COMPOSE_VERSION=${DOCKER_COMPOSE_VERSION:-1.23.1}
 NODE_VERSION=${TRAVIS_NODE_VERSION:-10}
 
+if [ ! -z "${DOCKERHUB_PULL_USERNAME:-}" ]; then
+  echo "${DOCKERHUB_PULL_PASSWORD}" | docker login --username "${DOCKERHUB_PULL_USERNAME}" --password-stdin
+fi
+
 docker run -d --name navy-test-runner-daemon --privileged \
   -v $(pwd):/usr/src/app \
   docker:$DOCKER_TAG --storage-driver=overlay

--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -24,6 +24,8 @@ docker build \
     -f test/integration/runner/Dockerfile \
     --build-arg DOCKER_COMPOSE_VERSION=$DOCKER_COMPOSE_VERSION \
     --build-arg NODE_VERSION=$NODE_VERSION \
+    --build-arg DOCKERHUB_PULL_USERNAME=$DOCKERHUB_PULL_USERNAME \
+    --build-arg DOCKERHUB_PULL_PASSWORD=$DOCKERHUB_PULL_PASSWORD \
     .
 
 echo ""

--- a/test/integration/runner/Dockerfile
+++ b/test/integration/runner/Dockerfile
@@ -9,6 +9,11 @@ RUN apt-get update -y && apt-get install -y build-essential git curl
 
 RUN curl -sL https://deb.nodesource.com/setup_$NODE_VERSION.x | bash - && apt-get install -y nodejs software-properties-common python
 
+RUN apt-get install -y apt-transport-https ca-certificates gnupg lsb-release
+RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+RUN echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+RUN apt-get update -y && apt-get install docker-ce-cli
+
 RUN curl -L https://github.com/docker/compose/releases/download/$DOCKER_COMPOSE_VERSION/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
 RUN chmod +x /usr/local/bin/docker-compose
 

--- a/test/integration/runner/Dockerfile
+++ b/test/integration/runner/Dockerfile
@@ -2,6 +2,8 @@ FROM ubuntu:16.04
 
 ARG DOCKER_COMPOSE_VERSION
 ARG NODE_VERSION
+ARG DOCKERHUB_PULL_USERNAME
+ARG DOCKERHUB_PULL_PASSWORD
 
 RUN apt-get update -y && apt-get install -y build-essential git curl
 
@@ -12,6 +14,12 @@ RUN chmod +x /usr/local/bin/docker-compose
 
 ADD ./test/integration/runner/docker-entrypoint.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+ENV DOCKERHUB_PULL_USERNAME $DOCKERHUB_PULL_USERNAME
+ENV DOCKERHUB_PULL_PASSWORD $DOCKERHUB_PULL_PASSWORD
+
+ADD ./test/integration/runner/docker-login.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-login.sh
 
 WORKDIR /usr/src/app
 ADD package.json ./

--- a/test/integration/runner/docker-entrypoint.sh
+++ b/test/integration/runner/docker-entrypoint.sh
@@ -6,4 +6,6 @@ if [ -z "$DOCKER_HOST" -a "$DOCKER_PORT_2375_TCP" ]; then
 	export DOCKER_HOST='tcp://docker:2375'
 fi
 
+/usr/local/bin/docker-login.sh
+
 exec "$@"

--- a/test/integration/runner/docker-login.sh
+++ b/test/integration/runner/docker-login.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+
+if [ ! -z "${DOCKERHUB_PULL_USERNAME:-}" ]; then
+  echo "${DOCKERHUB_PULL_PASSWORD}" | docker login --username "${DOCKERHUB_PULL_USERNAME}" --password-stdin
+fi


### PR DESCRIPTION
Travis CI was unable to build and run the integration tests, due to immediately hitting Docker Hub image pull rate limits.

Docker Hub limits the pull rate on a per-IP address basis if not logged in, or a per-account basis if logged in.

This PR ensures Docker is logged in during the integration tests in Travis CI, to provide a per-account pull rate, rather than share the rate with whatever IP Travis CI is using.

This requires these environment variables to be set in Travis CI:
DOCKERHUB_PULL_USERNAME
DOCKERHUB_PULL_PASSWORD
