### PR TITLE
Configurable auto proxy port

### DIFF
--- a/docs/navyfile-config.md
+++ b/docs/navyfile-config.md
@@ -18,6 +18,9 @@ module.exports = {
     'myservice',
     'myotherservice'
   ],
+  httpProxyAutoPorts: [
+    4080,
+  ],
   httpProxy: {
     myotherservice: { port: 8080 }
   },
@@ -38,9 +41,13 @@ Specifies a list of plugins to load at runtime. This should be an array of strin
 
 A list of service names in the compose configuration which should be selected by default when doing a `navy launch` with a Navy which hasn't been launched yet.
 
+### `httpProxyAutoPorts: ?Array<Number | string>`
+
+If using the [built in HTTP proxy](http-proxy.md), you can tell Navy to automatically register a service with the HTTP proxy, if it publishes any port in this list. This overrides port 80 for automatic registration.
+
 ### `httpProxy: ?{[key: string]: { port: Number }}`
 
-If using the [built in HTTP proxy](http-proxy.md), you can tell Navy what port a service listens for HTTP connections here. If a service publishes port 80, it will automatically be registered with the HTTP proxy, so configuration here is unnecessary.
+If using the [built in HTTP proxy](http-proxy.md), you can tell Navy what port a service listens for HTTP connections here. If a service publishes port 80, or alternatively a port specified in `httpProxyAutoPorts`, it will automatically be registered with the HTTP proxy, so configuration here is unnecessary.
 
 ### `ignoreUnauthorizedRequestsForRegistries: ?Array<string>`
 

--- a/test/integration/features/__steps__/http-proxy.js
+++ b/test/integration/features/__steps__/http-proxy.js
@@ -16,6 +16,16 @@ export default function () {
     this.serviceForProxy = 'helloworld-otherport'
   })
 
+  this.When(/I launch a service which exposes a different port which has been explicitly configured to use the HTTP proxy, not port 80$/, async function () {
+    await this.navy.launch(['helloworld-otherportnot80'])
+    this.serviceForProxy = 'helloworld-otherportnot80'
+  })
+
+  this.When(/I launch a service which exposes a different port which has been explicitly configured as a HTTP proxy auto-port$/, async function () {
+    await this.navy.launch(['helloworld-otherautoport'])
+    this.serviceForProxy = 'helloworld-otherautoport'
+  })
+
   this.Then(/I should be able to make a HTTP request to the service through the proxy$/, async function () {
     await retry(async () => {
       const res = await fetch(await this.navy.url(this.serviceForProxy))

--- a/test/integration/features/http-proxy.feature
+++ b/test/integration/features/http-proxy.feature
@@ -9,3 +9,13 @@ Feature: Navy HTTP proxy
     Given I am working with a test navy which has a service with a different port
     When I launch a service which exposes a different port which has been explicitly configured to use the HTTP proxy
     Then I should be able to make a HTTP request to the service through the proxy
+
+  Scenario: Launching a service and using the HTTP proxy on a different port, not port 80
+    Given I am working with a test navy which has a service with a different port, not port 80
+    When I launch a service which exposes a different port which has been explicitly configured to use the HTTP proxy, not port 80
+    Then I should be able to make a HTTP request to the service through the proxy
+
+  Scenario: Launching a service and using the HTTP proxy with a different auto-port
+      Given I am working with a test navy which has a service with a different port, with a custom proxy auto-port
+      When I launch a service which exposes a different port which has been explicitly configured as a HTTP proxy auto-port
+      Then I should be able to make a HTTP request to the service through the proxy

--- a/test/integration/steps/navy.js
+++ b/test/integration/steps/navy.js
@@ -19,6 +19,14 @@ export default function () {
     this.navy = await setUpNavy('dev', 'http-proxy-custom-port')
   })
 
+  this.Given(/I am working with a test navy which has a service with a different port, not port 80$/, async function () {
+    this.navy = await setUpNavy('dev', 'http-proxy-custom-port-not-80')
+  })
+
+  this.Given(/I am working with a test navy which has a service with a different port, with a custom proxy auto-port$/, async function () {
+    this.navy = await setUpNavy('dev', 'http-proxy-custom-auto-port')
+  })
+
   this.Given(/I am working with a test navy which has a fixed external port$/, async function () {
     this.navy = await setUpNavy('dev', 'with-fixed-port')
   })

--- a/test/integration/test-projects/http-proxy-custom-auto-port/.env
+++ b/test/integration/test-projects/http-proxy-custom-auto-port/.env
@@ -1,0 +1,2 @@
+# Used to test environments without normal docker-compose.yml file
+COMPOSE_FILE=./services.yml

--- a/test/integration/test-projects/http-proxy-custom-auto-port/Navyfile.js
+++ b/test/integration/test-projects/http-proxy-custom-auto-port/Navyfile.js
@@ -1,0 +1,5 @@
+module.exports = {
+  httpProxyAutoPorts: [
+    '4080',
+  ],
+}

--- a/test/integration/test-projects/http-proxy-custom-auto-port/services.yml
+++ b/test/integration/test-projects/http-proxy-custom-auto-port/services.yml
@@ -1,0 +1,9 @@
+version: '2'
+
+services:
+  helloworld-otherautoport:
+    image: dockercloud/hello-world
+    ports:
+      - "4080"
+    environment:
+      LISTEN_PORT: "4080"

--- a/test/integration/test-projects/http-proxy-custom-port-not-80/.env
+++ b/test/integration/test-projects/http-proxy-custom-port-not-80/.env
@@ -1,0 +1,2 @@
+# Used to test environments without normal docker-compose.yml file
+COMPOSE_FILE=./services.yml

--- a/test/integration/test-projects/http-proxy-custom-port-not-80/Navyfile.js
+++ b/test/integration/test-projects/http-proxy-custom-port-not-80/Navyfile.js
@@ -1,0 +1,5 @@
+module.exports = {
+  httpProxy: {
+    'helloworld-otherportnot80': { port: 8000 },
+  },
+}

--- a/test/integration/test-projects/http-proxy-custom-port-not-80/services.yml
+++ b/test/integration/test-projects/http-proxy-custom-port-not-80/services.yml
@@ -1,0 +1,9 @@
+version: '2'
+
+services:
+  helloworld-otherportnot80:
+    image: dockercloud/hello-world
+    ports:
+      - "8000"
+    environment:
+      LISTEN_PORT: "8000"


### PR DESCRIPTION
Allow port config for auto proxy (default 80)

Adds new Navyfile config setting:
httpProxyAutoPorts

This overrides the default of port 80, for automatically
proxying using the internal HTTP proxy.

httpProxyAutoPorts should be an array of strings or integers,
representing port numbers.